### PR TITLE
Fix the integration into other projects

### DIFF
--- a/src/tnetstrings.app.src
+++ b/src/tnetstrings.app.src
@@ -2,11 +2,12 @@
  [
   {description, ""},
   {vsn, "0.1"},
+  {modules, []},
   {registered, []},
   {applications, [
                   kernel,
                   stdlib
                  ]},
-  {mod, { }},
+  {mod, {tnetstrings, []}},
   {env, []}
  ]}.

--- a/src/tnetstrings.app.src
+++ b/src/tnetstrings.app.src
@@ -1,6 +1,6 @@
 {application, tnetstrings,
  [
-  {description, ""},
+  {description, "TNetStrings for Erlang"},
   {vsn, "0.1"},
   {modules, []},
   {registered, []},


### PR DESCRIPTION
Rebar `generate`'s command crashed when adding your tnetstrings as a dependency into another project.
Indeed, `tnetstrings.app.src` missed some informations and the template generation failed. Should be fixed now.

Oh, and btw, I added a tiny description into the file, because everyone loves descriptions ;)

Joyeux Noël :)
